### PR TITLE
Export public-facing interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ namespace Payloads {
  *
  * @see https://docs.pally.gg/developers/websockets#campaigntip-notify
  */
-interface CampaignTip {
+export interface CampaignTip {
 	/**
 	 * The unique identifier for the tip.
 	 */
@@ -91,7 +91,7 @@ interface CampaignTip {
 /**
  * @see https://docs.pally.gg/developers/websockets#campaigntip-notify
  */
-type Page = Payloads.CampaignTipNotify.Page;
+export type Page = Payloads.CampaignTipNotify.Page;
 
 type Events = {
 	connect: () => void;


### PR DESCRIPTION
This exports the public facing interfaces/types used in the emitter events, removing the need to re-define typing when defining listeners outside the `.on()` call.

```ts
import Pally, { type CampaignTip } from 'pally.gg';

const onTip = (tip: CampaignTip) => { /* Some Code */ }
const client = new Pally.Client(...);

client.on('campaigntip.notify', onTip.bind(someScope)); // No TS Errors
```